### PR TITLE
USB-Audio/Realtek/ALC4080: conditional S/PDIF index, add back microphone

### DIFF
--- a/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
+++ b/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
@@ -1,3 +1,14 @@
+Define.SPDIFIndex "3"
+
+If.asus-rog-usb {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB(0b05:1996)"
+	}
+	True.Define.SPDIFIndex "2"
+}
+
 SectionDevice."Speaker" {
 	Comment "Speakers"
 	Value {
@@ -23,7 +34,7 @@ SectionDevice."SPDIF" {
 	Comment "S/PDIF Out"
 	Value {
 		PlaybackPriority 100
-		PlaybackPCM "hw:${CardId},3"
+		PlaybackPCM "hw:${CardId},${var:SPDIFIndex}"
 		PlaybackMixerElem "IEC958"
 	}
 }
@@ -47,10 +58,19 @@ SectionDevice."Mic" {
 		cset "name='Mic Capture Switch' on"
 	]
 
-	Comment "Microphone"
+	Comment "Front Microphone"
 	Value {
 		CapturePriority 200
 		CapturePCM "hw:${CardId},2"
+		JackControl "Mic - Input Jack"
+		CaptureMixerElem "Mic"
+	}
+
+	# On ASUS ROG Maximus XIII and others, back microphone
+	Comment "Microphone"
+	Value {
+		CapturePriority 300
+		CapturePCM "hw:${CardId}"
 		JackControl "Mic - Input Jack"
 		CaptureMixerElem "Mic"
 	}

--- a/ucm2/USB-Audio/Realtek/ALC4080.conf
+++ b/ucm2/USB-Audio/Realtek/ALC4080.conf
@@ -1,5 +1,5 @@
 Comment "USB-audio on Realtek ALC4080"
 SectionUseCase."HiFi" {
 	File "/USB-Audio/Realtek/ALC4080-HiFi.conf"
-	Comment "Default Alsa Profile"
+	Comment "Play HiFi quality Music"
 }


### PR DESCRIPTION
Fixes ASUS ROG Maximus XIII support.

C/Sub port is not tested.